### PR TITLE
slamdunk: phil's updates

### DIFF
--- a/docs/plots.md
+++ b/docs/plots.md
@@ -85,6 +85,7 @@ config = {
     'logswitch': False,                     # Show the 'Log10' switch?
     'logswitch_active': False,              # Initial display with 'Log10' active?
     'logswitch_label': 'Log10',             # Label for 'Log10' button
+    'hide_zero_cats': True,                 # Hide categories where data for all samples is 0
     # Customising the plot
     'title': None,                          # Plot title
     'xlab': None,                           # X axis label

--- a/multiqc/modules/slamdunk/slamdunk.py
+++ b/multiqc/modules/slamdunk/slamdunk.py
@@ -24,133 +24,96 @@ class MultiqcModule(BaseMultiqcModule):
         super(MultiqcModule, self).__init__(name='Slamdunk', anchor='slamdunk',
         href='http://t-neumann.github.io/slamdunk/',
         info="is a tool to analyze SLAMSeq data.")
-
-        self.slamdunk_data = dict()
-        
-        self.PCA_data = dict()
-        
-        self.utrates_data = dict()
-        
-        self.rates_data_plus = dict()
-        self.rates_data_minus = dict()
-        
-        self.nontc_per_readpos_plus = dict()
-        self.nontc_per_readpos_minus = dict()
-        
-        self.tc_per_readpos_plus = dict()
-        self.tc_per_readpos_minus = dict()
-        
-        self.nontc_per_utrpos_plus = dict()
-        self.nontc_per_utrpos_minus = dict()
-        
-        self.tc_per_utrpos_plus = dict()
-        self.tc_per_utrpos_minus = dict()
-
-        # List of plots to produce
-        produce = []
-            
-        for f in self.find_log_files(config.sp['slamdunk']['summary'], filehandles = True):
-            self.parseSummary(f)
-            
-        if len(self.slamdunk_data) == 0:
-            log.debug("Could not find any reports in {}".format(config.analysis_dir))
-        else :
-            produce.append("summary")
-            
-        log.debug("Parsing PCA reports.")
-            
-        for f in self.find_log_files(config.sp['slamdunk']['PCA'], filehandles = True):
-            self.parsePCA(f)
-            
-        if len(self.PCA_data) == 0:
-            log.debug("Could not find PCA reports in {}".format(config.analysis_dir))
-        else :
-            produce.append("PCA")
-            
-        log.debug("Parsing UTR rates reports. This can take a while...")
-                        
-        for f in self.find_log_files(config.sp['slamdunk']['utrrates'], filehandles = True):
-            self.parseUtrRates(f)
-            
-        if len(self.utrates_data) == 0:
-            log.debug("Could not find UTR rates reports in {}".format(config.analysis_dir))
-        else :
-            self.write_data_file(self.utrates_data, 'multiqc_slamdunk_utrrates')
-            produce.append("utrates")            
-
-        log.debug("Parsing read rates reports.")
-            
-        for f in self.find_log_files(config.sp['slamdunk']['rates'], filehandles = True):
-            self.parseSlamdunkRates(f)
-            
-        if len(self.rates_data_plus) == 0:
-            log.debug("Could not find read rates reports in {}".format(config.analysis_dir))
-        else :
-            self.write_data_file(self.rates_data_plus, 'multiqc_slamdunk_readrates_plus')
-            self.write_data_file(self.rates_data_minus, 'multiqc_slamdunk_readrates_minus')
-            produce.append("readrates")
-            
-        log.debug("Parsing rates per read position reports.")
-            
-        for f in self.find_log_files(config.sp['slamdunk']['tcperreadpos'], filehandles = True):
-            self.parseSlamdunkTCPerReadpos(f)
-            
-        if len(self.tc_per_readpos_plus) == 0:
-            log.debug("Could not find conversion per read position reports in {}".format(config.analysis_dir))
-        else :
-            self.write_data_file(self.tc_per_readpos_plus, 'multiqc_slamdunk_tcperreadpos_plus')
-            self.write_data_file(self.nontc_per_readpos_plus, 'multiqc_slamdunk_nontcperreadpos_plus')
-            self.write_data_file(self.tc_per_readpos_minus, 'multiqc_slamdunk_tcperreadpos_minus')
-            self.write_data_file(self.nontc_per_readpos_minus, 'multiqc_slamdunk_nontcperreadpos_minus')
-            produce.append("readpos")
-            
-        log.debug("Parsing rates per UTR position reports.")
-
-        for f in self.find_log_files(config.sp['slamdunk']['tcperutrpos'], filehandles = True):
-            self.parseSlamdunkTCPerUtrpos(f)
-            
-        if len(self.nontc_per_utrpos_plus) == 0:
-            log.debug("Could not find conversion per UTR position reports in {}".format(config.analysis_dir))
-        else :
-            self.write_data_file(self.tc_per_utrpos_plus, 'multiqc_slamdunk_tcperutrpos_plus')
-            self.write_data_file(self.nontc_per_utrpos_plus, 'multiqc_slamdunk_nontcperutrpos_plus')
-            self.write_data_file(self.tc_per_utrpos_minus, 'multiqc_slamdunk_tcperutrpos_minus')
-            self.write_data_file(self.nontc_per_utrpos_minus, 'multiqc_slamdunk_nontcperutrpos_minus')
-            produce.append("utrpos")
-        
-        if not produce:
-            log.debug("No slamdunk reports found.")
-            raise UserWarning
         
         # Start the sections
         self.sections = list()
         
-        # Basic Stats Table
-        if "summary" in produce:
+        num_reports = 0
+        
+        self.plot_cols = [
+            '#fdbf6f','#2171B5','#6BAED6','#C6DBEF','#74C476','#C7E9C0',
+            '#D9D9D9','#969696','#525252','#DADAEB','#9E9AC8','#6A51A3'
+        ]
+        
+        # Summary Reports
+        self.slamdunk_data = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['summary'], filehandles = True):
+            self.parseSummary(f)
+        if len(self.slamdunk_data) > 0:
             self.slamdunkGeneralStatsTable()
             self.slamdunkFilterStatsTable()
-        
-        # PCA plot
-        if "PCA" in produce:
-            self.slamdunkPCAPlot()
-        
-        # Utr rates plot
-        if "utrates" in produce:
-            self.slamdunkUtrRatesPlot()
+            log.debug("Found {} summary reports".format(len(self.slamdunk_data)))
+            num_reports = max(num_reports, len(self.slamdunk_data))
 
-        # Rates plot
-        if "readrates" in produce:
+        # PCA Plots
+        self.PCA_data = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['PCA'], filehandles = True):
+            self.parsePCA(f)
+        if len(self.PCA_data) > 0:
+            self.slamdunkPCAPlot()
+            log.debug("Found {} PCA plots".format(len(self.PCA_data)))
+            num_reports = max(num_reports, len(self.PCA_data))
+
+        # UTR Rate reports
+        self.utrates_data = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['utrrates'], filehandles = True):
+            self.parseUtrRates(f)
+        if len(self.utrates_data) > 0:
+            self.write_data_file(self.utrates_data, 'multiqc_slamdunk_utrrates')
+            self.slamdunkUtrRatesPlot()
+            log.debug("Found {} UTR rate reports".format(len(self.utrates_data)))
+            num_reports = max(num_reports, len(self.utrates_data))
+        
+        # Read rate reports
+        self.rates_data_plus = dict()
+        self.rates_data_minus = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['rates'], filehandles = True):
+            self.parseSlamdunkRates(f)
+        if len(self.rates_data_plus) > 0:
+            self.write_data_file(self.rates_data_plus, 'multiqc_slamdunk_readrates_plus')
+            self.write_data_file(self.rates_data_minus, 'multiqc_slamdunk_readrates_minus')
             self.slamdunkOverallRatesPlot()
+            log.debug("Found {} read rate reports".format(len(self.rates_data_plus)))
+            num_reports = max(num_reports, len(self.rates_data_plus))
         
-        # TC per read position plot
-        if "readpos" in produce:
+        # TCP error read rate
+        self.nontc_per_readpos_plus = dict()
+        self.nontc_per_readpos_minus = dict()
+        self.tc_per_readpos_plus = dict()
+        self.tc_per_readpos_minus = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['tcperreadpos'], filehandles = True):
+            self.parseSlamdunkTCPerReadpos(f)
+        if len(self.tc_per_readpos_plus) > 0:
+            self.write_data_file(self.tc_per_readpos_plus, 'multiqc_slamdunk_tcperreadpos_plus')
+            self.write_data_file(self.nontc_per_readpos_plus, 'multiqc_slamdunk_nontcperreadpos_plus')
+            self.write_data_file(self.tc_per_readpos_minus, 'multiqc_slamdunk_tcperreadpos_minus')
+            self.write_data_file(self.nontc_per_readpos_minus, 'multiqc_slamdunk_nontcperreadpos_minus')
             self.slamdunkTcPerReadPosPlot()
+            log.debug("Found {} TCP error read rate reports".format(len(self.tc_per_readpos_plus)))
+            num_reports = max(num_reports, len(self.tc_per_readpos_plus))
         
-        # TC per UTR position plot
-        if "utrpos" in produce:
+        # Non-TCP error read rate
+        self.nontc_per_utrpos_plus = dict()
+        self.nontc_per_utrpos_minus = dict()
+        self.tc_per_utrpos_plus = dict()
+        self.tc_per_utrpos_minus = dict()
+        for f in self.find_log_files(config.sp['slamdunk']['tcperutrpos'], filehandles = True):
+            self.parseSlamdunkTCPerUtrpos(f)
+        if len(self.nontc_per_utrpos_plus) > 0:
+            self.write_data_file(self.tc_per_utrpos_plus, 'multiqc_slamdunk_tcperutrpos_plus')
+            self.write_data_file(self.nontc_per_utrpos_plus, 'multiqc_slamdunk_nontcperutrpos_plus')
+            self.write_data_file(self.tc_per_utrpos_minus, 'multiqc_slamdunk_tcperutrpos_minus')
+            self.write_data_file(self.nontc_per_utrpos_minus, 'multiqc_slamdunk_nontcperutrpos_minus')
             self.slamdunkTcPerUTRPosPlot()
-            
-        log.info("Found " + str(len(self.slamdunk_data)) + " reports")
+            log.debug("Found {} non TCP error read rate reports".format(len(self.nontc_per_utrpos_plus)))
+            num_reports = max(num_reports, len(self.nontc_per_utrpos_plus))
+        
+        if num_reports == 0:
+            log.debug("No slamdunk reports found.")
+            raise UserWarning
+        else:
+            log.info("Found {} reports".format(num_reports))
+        
         
     def parsePCA(self, f):
         
@@ -160,16 +123,14 @@ class MultiqcModule(BaseMultiqcModule):
         for line in f['f']:
             fields = line.rstrip().split('\t')
             
-            sample = fields[0]
+            sample = self.clean_s_name(fields[0],f['root'])
             PC1 = fields[1]
             PC2 = fields[2]
             
-            self.PCA_data[sample] = dict()
-
             self.PCA_data[sample] = [{'x': float(PC1), 'y': float(PC2)}]
         
         
-    def parseUtrRates(self, f) :
+    def parseUtrRates(self, f):
                 
         # Skip comment line #
         next(f['f'])
@@ -177,7 +138,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Read median header
         line = next(f['f'])
         
-        if "Conversions=" in line :
+        if "Conversions=" in line:
             
             sample = f['s_name']
             self.utrates_data[sample] = OrderedDict()
@@ -188,8 +149,7 @@ class MultiqcModule(BaseMultiqcModule):
                 type, value = conversion.split(":")
                 self.utrates_data[sample][type] = float(value)
         
-        else :
-            
+        else:
             log.warning("Malformed UTR rates header. Conversion rates per UTR plot will be affected.")
 
     def parseSlamdunkRates(self, f):
@@ -204,34 +164,33 @@ class MultiqcModule(BaseMultiqcModule):
         baseDict = {}
         order = {}
         
-        for i in range(1, len(bases)) :
+        for i in range(1, len(bases)):
             order[i] = bases[i]
-                    
+        
         for line in f['f']:
             values = line.rstrip().split('\t')
             base = values[0]
             baseDict[base]= {}
             
-            for i in range(1, len(values)) :
-            
+            for i in range(1, len(values)):
                 baseDict[base][order[i]] = int(values[i])
-                
-        divisor = {}      
+        
+        divisor = {}
         
         for fromBase in baseDict:
             for toBase in baseDict[fromBase]:
-                if(toBase.islower()) :
-                    if not fromBase.lower() in divisor :
+                if(toBase.islower()):
+                    if not fromBase.lower() in divisor:
                         divisor[fromBase.lower()] = 0
                     divisor[fromBase.lower()] += baseDict[fromBase][toBase]
                 else:
-                    if not fromBase in divisor :
+                    if not fromBase in divisor:
                         divisor[fromBase] = 0
                     divisor[fromBase] += baseDict[fromBase][toBase]
         
         for fromBase in baseDict:
             for toBase in baseDict[fromBase]:
-                if(toBase.islower()) :
+                if(toBase.islower()):
                     baseDict[fromBase][toBase] = baseDict[fromBase][toBase] / float(divisor[fromBase.lower()]) * 100
                 else:
                     baseDict[fromBase][toBase] = baseDict[fromBase][toBase] / float(divisor[fromBase]) * 100
@@ -242,11 +201,11 @@ class MultiqcModule(BaseMultiqcModule):
         for fromBase in baseDict:
             for toBase in baseDict[fromBase]:
                 if fromBase != "N" and toBase.upper() != "N" and fromBase != toBase.upper():
-                    if(toBase.islower()) :
+                    if(toBase.islower()):
                         self.rates_data_minus[sample][fromBase + ">" + toBase.upper()] = baseDict[fromBase][toBase]
-                    else :
+                    else:
                         self.rates_data_plus[sample][fromBase + ">" + toBase] = baseDict[fromBase][toBase]
-                        
+
     def parseSlamdunkTCPerReadpos(self, f):
         
         sample = f['s_name']
@@ -264,22 +223,22 @@ class MultiqcModule(BaseMultiqcModule):
         
         for line in f['f']:
             values = line.rstrip().split('\t')
-            if int(values[4]) > 0 :
+            if int(values[4]) > 0:
                 self.nontc_per_readpos_plus[sample][pos] = float(int(values[0])) / int(values[4]) * 100
                 self.tc_per_readpos_plus[sample][pos] = float(int(values[2])) / int(values[4]) * 100
-            else :
+            else:
                 self.nontc_per_readpos_plus[sample][pos] = 0
                 self.tc_per_readpos_plus[sample][pos] = 0
-                
+            
             if int(values[5]) > 0:
                 self.nontc_per_readpos_minus[sample][pos] = float(int(values[1])) / int(values[5]) * 100
                 self.tc_per_readpos_minus[sample][pos] = float(int(values[3])) / int(values[5]) * 100
             else:
                 self.nontc_per_readpos_minus[sample][pos] = 0
                 self.tc_per_readpos_minus[sample][pos] = 0
-                
-            pos += 1
             
+            pos += 1
+
     def parseSlamdunkTCPerUtrpos(self, f):
         
         sample = f['s_name']
@@ -297,22 +256,22 @@ class MultiqcModule(BaseMultiqcModule):
         
         for line in f['f']:
             values = line.rstrip().split('\t')
-            if int(values[4]) > 0 :
+            if int(values[4]) > 0:
                 self.nontc_per_utrpos_plus[sample][pos] = float(int(values[0])) / int(values[4]) * 100
                 self.tc_per_utrpos_plus[sample][pos] = float(int(values[2])) / int(values[4]) * 100
-            else :
+            else:
                 self.nontc_per_utrpos_plus[sample][pos] = 0
                 self.tc_per_utrpos_plus[sample][pos] = 0
-                
+            
             if int(values[5]) > 0:
                 self.nontc_per_utrpos_minus[sample][pos] = float(int(values[1])) / int(values[5]) * 100
                 self.tc_per_utrpos_minus[sample][pos] = float(int(values[3])) / int(values[5]) * 100
             else:
                 self.nontc_per_utrpos_minus[sample][pos] = 0
                 self.tc_per_utrpos_minus[sample][pos] = 0
-                
+            
             pos += 1
-    
+
     def parseSummary(self, f):
         
         # Skip comment line #
@@ -320,33 +279,33 @@ class MultiqcModule(BaseMultiqcModule):
         
         # Skip header line "FileName..."
         columnCount = next(f['f']).count("\t") + 1
-            
+        
         for line in f['f']:
 
             fields = line.rstrip().split("\t")
-            self.slamdunk_data[self.clean_s_name(fields[0],"")] = dict()
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['sequenced'] = int(fields[4])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['mapped'] = int(fields[5])
-            #self.slamdunk_data[self.clean_s_name(fields[0],"")]['deduplicated'] = int(fields[6])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['mqfiltered'] = int(fields[7])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['idfiltered'] = int(fields[8])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['nmfiltered'] = int(fields[9])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['multimapper'] = int(fields[10])
-            self.slamdunk_data[self.clean_s_name(fields[0],"")]['retained'] = int(fields[11])
+            s_name = self.clean_s_name(fields[0],f['root'])
+            self.slamdunk_data[s_name] = dict()
+            self.slamdunk_data[s_name]['sequenced'] = int(fields[4])
+            self.slamdunk_data[s_name]['mapped'] = int(fields[5])
+            #self.slamdunk_data[s_name]['deduplicated'] = int(fields[6])
+            self.slamdunk_data[s_name]['mqfiltered'] = int(fields[7])
+            self.slamdunk_data[s_name]['idfiltered'] = int(fields[8])
+            self.slamdunk_data[s_name]['nmfiltered'] = int(fields[9])
+            self.slamdunk_data[s_name]['multimapper'] = int(fields[10])
+            self.slamdunk_data[s_name]['retained'] = int(fields[11])
             
             # Additional Count Column found in Table
             if columnCount == 14:
-                self.slamdunk_data[self.clean_s_name(fields[0],"")]['counted'] = int(fields[12])
-                
-        self.add_data_source(f)
+                self.slamdunk_data[s_name]['counted'] = int(fields[12])
         
+        self.add_data_source(f)
+
     def slamdunkGeneralStatsTable(self):
         """ Take the parsed summary stats from Slamdunk and add it to the
         basic stats table at the top of the report """
 
 
         headers = OrderedDict()
-        
         headers['counted'] = {
             'title': 'Counted',
             'description': '# reads counted within 3\'UTRs',
@@ -356,7 +315,6 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'YlGn',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['retained'] = {
             'title': 'Retained',
             'description': '# retained reads after filtering',
@@ -366,43 +324,6 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'YlGn',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
-#         headers['multimapper'] = {
-#             'title': 'Multimap-Filtered',
-#             'description': '# multimap-filtered reads',
-#             'shared_key': 'read_count',
-#             'min': 0,
-#             'format': '{:.f}',
-#             'scale': 'OrRd',
-#         }
-#         
-#         headers['nmfiltered'] = {
-#             'title': 'NM-Filtered',
-#             'description': '# NM-filtered reads',
-#             'shared_key': 'read_count',
-#             'min': 0,
-#             'format': '{:.f}',
-#             'scale': 'OrRd',
-#         }
-#         
-#         headers['idfiltered'] = {
-#             'title': 'Identity-Filtered',
-#             'description': '# identity-filtered reads',
-#             'shared_key': 'read_count',
-#             'min': 0,
-#             'format': '{:.f}',
-#             'scale': 'OrRd',
-#         }
-#         
-#         headers['mqfiltered'] = {
-#             'title': 'MQ-Filtered',
-#             'description': '# MQ-filtered reads',
-#             'shared_key': 'read_count',
-#             'min': 0,
-#             'format': '{:.f}',
-#             'scale': 'OrRd',
-#         }
-        
         headers['mapped'] = {
             'title': 'Mapped',
             'description': '# mapped reads',
@@ -412,7 +333,6 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'YlGn',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['sequenced'] = {
             'title': 'Sequenced',
             'description': '# sequenced reads',
@@ -424,13 +344,13 @@ class MultiqcModule(BaseMultiqcModule):
         }
         
         self.general_stats_addcols(self.slamdunk_data, headers)
-        
+
     def slamdunkFilterStatsTable(self):
         """ Take the parsed filter stats from Slamdunk and add it to a separate table """
 
         headers = OrderedDict()
-        
         headers['mapped'] = {
+            'namespace': 'Slamdunk',
             'title': 'Mapped',
             'description': '# mapped reads',
             'shared_key': 'read_count',
@@ -439,8 +359,8 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'YlGn',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['multimapper'] = {
+            'namespace': 'Slamdunk',
             'title': 'Multimap-Filtered',
             'description': '# multimap-filtered reads',
             'shared_key': 'read_count',
@@ -449,8 +369,8 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'OrRd',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['nmfiltered'] = {
+            'namespace': 'Slamdunk',
             'title': 'NM-Filtered',
             'description': '# NM-filtered reads',
             'shared_key': 'read_count',
@@ -459,8 +379,8 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'OrRd',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['idfiltered'] = {
+            'namespace': 'Slamdunk',
             'title': 'Identity-Filtered',
             'description': '# identity-filtered reads',
             'shared_key': 'read_count',
@@ -469,8 +389,8 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'OrRd',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         headers['mqfiltered'] = {
+            'namespace': 'Slamdunk',
             'title': 'MQ-Filtered',
             'description': '# MQ-filtered reads',
             'shared_key': 'read_count',
@@ -479,7 +399,6 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'OrRd',
             'modify': lambda x: float(x) / 1000000.0,
         }
-        
         config = {
             'id': 'slamdunk_filtering_table',
             'min': 0,
@@ -488,182 +407,62 @@ class MultiqcModule(BaseMultiqcModule):
         self.sections.append({
             'name': 'Filter statistics',
             'anchor': 'slamdunk_filtering',
-            'content': '<p> This table shows the number of reads filtered with each filter criterion during filtering phase of slamdunk.</p>' +  
+            'content': '<p> This table shows the number of reads filtered with each filter criterion during filtering phase of slamdunk.</p>' +
                         plots.table.plot(self.slamdunk_data, headers, config)
         })
-                
+
     def slamdunkOverallRatesPlot (self):
         """ Generate the overall rates plot """
 
         pconfig = {
             'id': 'overallratesplot',
             'title': 'Overall conversion rates in reads',
-            'cpswitch' : False,
+            'cpswitch': False,
             'cpswitch_c_active': False,
-            'stacking' : 'normal',
+            'stacking': 'normal',
             'tt_decimals': 2,
             'tt_suffix': '%',
             'tt_percentages': False,
             'data_labels': [
                 "Plus Strand +",
-                "Minus Strand -", 
+                "Minus Strand -",
             ]
         }
         
         cats = [OrderedDict(), OrderedDict()]
-        
-        cats[0]['T>C'] = {
-            #'color': '#D7301F'
-            'color': '#fdbf6f'
-        }
-        cats[0]['A>T'] = {
-            #'color': '#C6DBEF'
-            'color': '#2171B5'
-        }
-        cats[0]['A>G'] = {
-            #'color': '#6BAED6'
-            'color': '#6BAED6'
-        }
-        cats[0]['A>C'] = {
-            #'color': '#2171B5'
-            'color': '#C6DBEF'
-        }
-        cats[0]['T>A'] = {
-            #'color': '#C7E9C0'
-            'color': '#74C476'
-        }
-        cats[0]['T>G'] = {
-            #'color': '#74C476'
-            'color': '#C7E9C0'
-        }
-        cats[0]['G>A'] = {
-            'color': '#D9D9D9'
-        }
-        cats[0]['G>T'] = {
-            'color': '#969696'
-        }
-        cats[0]['G>C'] = {
-            'color': '#525252'
-        }
-        cats[0]['C>A'] = {
-            'color': '#DADAEB'
-        }
-        cats[0]['C>T'] = {
-            'color': '#9E9AC8'
-        }
-        cats[0]['C>G'] = {
-            'color': '#6A51A3'
-        }
-        
-        cats[1]['A>G'] = {
-            #'color': '#D7301F'
-            'color': '#fdbf6f'
-        }
-        cats[1]['A>T'] = {
-            #'color': '#C6DBEF'
-            'color': '#2171B5'
-        }
-        cats[1]['A>C'] = {
-            #'color': '#2171B5'
-            'color': '#6BAED6'
-        }
-        cats[1]['T>A'] = {
-            #'color': '#C7E9C0'
-            'color': '#C6DBEF'
-        }
-        cats[1]['T>G'] = {
-            #'color': '#74C476'
-            'color': '#74C476'
-        }
-        cats[1]['T>C'] = {
-            #'color': '#238B45'
-            'color': '#C7E9C0'
-        }
-        cats[1]['G>A'] = {
-            'color': '#D9D9D9'
-        }
-        cats[1]['G>T'] = {
-            'color': '#969696'
-        }
-        cats[1]['G>C'] = {
-            'color': '#525252'
-        }
-        cats[1]['C>A'] = {
-            'color': '#DADAEB'
-        }
-        cats[1]['C>T'] = {
-            'color': '#9E9AC8'
-        }
-        cats[1]['C>G'] = {
-            'color': '#6A51A3'
-        }
+        keys = [
+            ['T>C', 'A>T', 'A>G', 'A>C', 'T>A', 'T>G', 'G>A', 'G>T', 'G>C', 'C>A', 'C>T', 'C>G'],
+            ['A>G','A>T','A>C','T>A','T>G','T>C','G>A','G>T','G>C','C>A','C>T','C>G']
+        ]
+        for i, k in enumerate(keys):
+            for j, v in enumerate(k):
+                cats[i][v] = { 'color': self.plot_cols[j] }
         
         self.sections.append({
             'name': 'Conversion rates per read',
             'anchor': 'slamdunk_overall_rates',
-            'content': '<p>This plot shows the individual conversion rates over all reads. \n\
-                        It shows these conversion rates strand-specific: This means for a properly labelled \n\
-                        sample you would see a T>C excess on \n\
-                        the plus-strand and an A>G excess on the minus strand. <br>\n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#rates" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.bargraph.plot([self.rates_data_plus,self.rates_data_minus], cats, pconfig)
+            'content': """<p>This plot shows the individual conversion rates over all reads.
+                        It shows these conversion rates strand-specific: This means for a properly labelled
+                        sample you would see a T&gt;C excess on the plus-strand and an A&gt;G excess on the minus strand
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#rates" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.bargraph.plot([self.rates_data_plus,self.rates_data_minus], cats, pconfig)
         })
     
-
+    
     def slamdunkUtrRatesPlot (self):
         """ Generate the UTR rates plot """
         
         cats = OrderedDict()
-        cats['T>C'] = {
-            #'color': '#D7301F'
-            'color': '#fdbf6f'
-        }
-        cats['A>T'] = {
-            #'color': '#C6DBEF'
-            'color': '#2171B5'
-        }
-        cats['A>G'] = {
-            #'color': '#6BAED6'
-            'color': '#6BAED6'
-        }
-        cats['A>C'] = {
-            #'color': '#2171B5'
-            'color': '#C6DBEF'
-        }
-        cats['T>A'] = {
-            #'color': '#C7E9C0'
-            'color': '#74C476'
-        }
-        cats['T>G'] = {
-            #'color': '#74C476'
-            'color': '#C7E9C0'
-        }
-        cats['G>A'] = {
-            'color': '#D9D9D9'
-        }
-        cats['G>T'] = {
-            'color': '#969696'
-        }
-        cats['G>C'] = {
-            'color': '#525252'
-        }
-        cats['C>A'] = {
-            'color': '#DADAEB'
-        }
-        cats['C>T'] = {
-            'color': '#9E9AC8'
-        }
-        cats['C>G'] = {
-            'color': '#6A51A3'
-        }
+        keys = ['T>C', 'A>T', 'A>G', 'A>C', 'T>A', 'T>G', 'G>A', 'G>T', 'G>C', 'C>A', 'C>T', 'C>G']
+        for i, v in enumerate(keys):
+            cats[v] = { 'color': self.plot_cols[i] }
 
         pconfig = {
             'id': 'slamdunk_utrratesplot',
             'title': 'Overall conversion rates per UTR',
-            'cpswitch' : False,
+            'cpswitch': False,
             'cpswitch_c_active': False,
-            'stacking' : 'normal',
+            'stacking': 'normal',
             'tt_decimals': 2,
             'tt_suffix': '%',
             'tt_percentages': False,
@@ -672,10 +471,9 @@ class MultiqcModule(BaseMultiqcModule):
         self.sections.append({
             'name': 'Conversion rates per UTR',
             'anchor': 'slamdunk_utr_rates',
-            'content': '<p>This plot shows the individual conversion rates for all UTRs.<br> \n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#utrrates" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.bargraph.plot(self.utrates_data, cats, pconfig)
+            'content': """<p>This plot shows the individual conversion rates for all UTRs
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#utrrates" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.bargraph.plot(self.utrates_data, cats, pconfig)
         })
     
     def slamdunkPCAPlot (self):
@@ -684,18 +482,18 @@ class MultiqcModule(BaseMultiqcModule):
         pconfig = {
             'id': 'slamdunk_pca',
             'title': 'Slamdunk PCA',
-            'xlab' : 'PC1',
-            'ylab' : 'PC2',
+            'xlab': 'PC1',
+            'ylab': 'PC2',
             'tt_label': 'PC1 {point.x:.2f}: PC2 {point.y:.2f}'
         }
         
         self.sections.append({
-            'name': 'PCA (T>C based)',
+            'name': 'PCA (T&gt;C based)',
             'anchor': 'slamdunk_PCA',
-            'content': '<p> This plot shows the principal components of samples based on the distribution of reads with T>C conversions within UTRs. <br>\n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#summary" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.scatter.plot(self.PCA_data, pconfig) 
+            'content': """<p> This plot shows the principal components of samples based
+                        on the distribution of reads with T&gt;C conversions within UTRs
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#summary" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.scatter.plot(self.PCA_data, pconfig)
         })
         
     def slamdunkTcPerReadPosPlot (self):
@@ -723,24 +521,22 @@ class MultiqcModule(BaseMultiqcModule):
             'tt_label': '<b>Pos {point.x}</b>: {point.y:.2f} %',
             'data_labels': [{'name': 'Forward reads +', 'ylab': 'Percent converted %'},
                             {'name': 'Reverse reads -', 'ylab': 'Percent converted %'}]
-        }        
+        }
         
         self.sections.append({
-            'name': 'Non T>C mutations over read positions',
+            'name': 'Non T&gt;C mutations over read positions',
             'anchor': 'slamdunk_nontcperreadpos',
-            'content': '<p>This plot shows the distribution of non T>C mutations across read positions. <br> \n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperreadpos" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.linegraph.plot([self.nontc_per_readpos_plus, self.nontc_per_readpos_minus], pconfig_nontc) 
+            'content': """<p>This plot shows the distribution of non T&gt;C mutations across read positions
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperreadpos" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.linegraph.plot([self.nontc_per_readpos_plus, self.nontc_per_readpos_minus], pconfig_nontc)
         })
         
         self.sections.append({
-            'name': 'T>C conversions over read positions',
+            'name': 'T&gt;C conversions over read positions',
             'anchor': 'slamdunk_tcperreadpos',
-            'content': '<p>This plot shows the distribution of T>C conversions across read positions. <br> \n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperreadpos" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.linegraph.plot([self.tc_per_readpos_plus, self.tc_per_readpos_minus], pconfig_tc) 
+            'content': """<p>This plot shows the distribution of T&gt;C conversions across read positions
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperreadpos" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.linegraph.plot([self.tc_per_readpos_plus, self.tc_per_readpos_minus], pconfig_tc)
         })
         
     def slamdunkTcPerUTRPosPlot (self):
@@ -768,22 +564,20 @@ class MultiqcModule(BaseMultiqcModule):
             'tt_label': '<b>Pos {point.x}</b>: {point.y:.2f} %',
             'data_labels': [{'name': 'UTRs on plus strand', 'ylab': 'Percent converted %'},
                             {'name': 'UTRs on minus strand', 'ylab': 'Percent converted %'}]
-        }        
+        }
         
         self.sections.append({
-            'name': 'Non T>C mutations over UTR positions',
+            'name': 'Non T&gt;C mutations over UTR positions',
             'anchor': 'slamdunk_nontcperutrpos',
-            'content': '<p>This plot shows the distribution of non T>C mutations across UTR positions for the last 200 bp from the 3\' UTR end. <br> \n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperutrpos" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.linegraph.plot([self.nontc_per_utrpos_plus, self.nontc_per_utrpos_minus], pconfig_nontc) 
+            'content': """<p>This plot shows the distribution of non T&gt;C mutations across UTR positions for the last 200 bp from the 3\' UTR end
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperutrpos" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.linegraph.plot([self.nontc_per_utrpos_plus, self.nontc_per_utrpos_minus], pconfig_nontc)
         })
         
         self.sections.append({
-            'name': 'T>C conversions over UTR positions',
+            'name': 'T&gt;C conversions over UTR positions',
             'anchor': 'tcperutrpos',
-            'content': '<p>This plot shows the distribution of T>C conversions across UTR positions for the last 200 bp from the 3\' UTR end . <br> \n\
-                        See the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperutrpos" target="_blank">slamdunk documentation</a> \n\
-                        for more information on how these numbers are generated.</p>' +  
-                        plots.linegraph.plot([self.tc_per_utrpos_plus, self.tc_per_utrpos_minus], pconfig_tc) 
+            'content': """<p>This plot shows the distribution of T&gt;C conversions across UTR positions for the last 200 bp from the 3\' UTR end
+                        (see the <a href="http://slamdunk.readthedocs.io/en/latest/Alleyoop.html#tcperutrpos" target="_blank">slamdunk docs</a>).</p>"""
+                        + plots.linegraph.plot([self.tc_per_utrpos_plus, self.tc_per_utrpos_minus], pconfig_tc)
         })

--- a/multiqc/modules/slamdunk/slamdunk.py
+++ b/multiqc/modules/slamdunk/slamdunk.py
@@ -466,6 +466,7 @@ class MultiqcModule(BaseMultiqcModule):
             'tt_decimals': 2,
             'tt_suffix': '%',
             'tt_percentages': False,
+            'hide_zero_cats': False
         }
         
         self.sections.append({

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -102,11 +102,12 @@ def plot (data, cats=None, pconfig={}):
                 except KeyError:
                     # Pad with NaNs when we have missing categories in a sample
                     thisdata.append(float('nan'))
-            if catcount > 0 and max(x for x in thisdata if not math.isnan(x)) > 0:
-                thisdict = { 'name': cats[idx][c]['name'], 'data': thisdata }
-                if 'color' in cats[idx][c]:
-                    thisdict['color'] = cats[idx][c]['color']
-                hc_data.append(thisdict)
+            if catcount > 0:
+                if pconfig.get('hide_zero_cats', True) is False or max(x for x in thisdata if not math.isnan(x)) > 0:
+                    thisdict = { 'name': cats[idx][c]['name'], 'data': thisdata }
+                    if 'color' in cats[idx][c]:
+                        thisdict['color'] = cats[idx][c]['color']
+                    hc_data.append(thisdict)
         
         # Remove empty samples
         for s, c in sample_dcount.items():


### PR DESCRIPTION
Hi @t-neumann!

Here are a few changes of mine as I went through the code. As far as I can tell, none of this makes any big difference to the final report.

* Added `f['root']` to the sample name cleaning, so that running with `-d` properly prepends the directory names
* Removed quite a lot of debugging statements
  * 90% of MultiQC users will probably never run MultiQC with slamdunk data (no offence meant!), so I'd prefer not to fill everyone's verbose logs up with these messages.
* Moved code around a bit so that it's a bit tidier (in my opinion)
  * There's a large dose of personal preference here, so feel free to revert any changes you don't like
* Tidied up some loose whitespace
* Removed commented out code
* Refactored colours for bar plots so that they're held in a single place and code is less verbose
* Switched out `>` in a bunch of places with the more HTML friendly `&gt;`
* Made multi-line strings use triple quotes: `"""`

I think that about covers it. Append `?w=1` on the GitHub code view URL to hide the whitespace-only changes.

Let me know what you think!

Phil